### PR TITLE
Instances support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 latch.pyc
 .idea
+*.pyc

--- a/latchapp.py
+++ b/latchapp.py
@@ -89,3 +89,42 @@ class LatchApp(LatchAuth):
             return self._http("GET", self.API_OPERATION_URL)
         else:
             return self._http("GET", self.API_OPERATION_URL + "/" + operation_id)
+
+    def getInstances(self, account_id, operation_id=None):
+        if operation_id == None:
+            return self._http("GET", self.API_INSTANCE_URL + "/" + account_id)
+        else:
+            return self._http("GET", self.API_INSTANCE_URL + "/" + account_id + "/op/" + operation_id)
+
+    def instanceStatus(self, instance_id, account_id, operation_id=None, silent=False, nootp=False):
+        if operation_id == None:
+            url = self.API_CHECK_STATUS_URL + "/" + account_id + "/i/" + instance_id
+        else:
+            url = self.API_CHECK_STATUS_URL + "/" + account_id + "/op/" + operation_id + "/i/" + instance_id
+        if nootp:
+            url += '/nootp'
+        if silent:
+            url += '/silent'
+        return self._http("GET", url)
+
+    def createInstance(self, name, account_id, operation_id=None):
+        # Only one at a time
+        params = {'instances': name}
+        if operation_id == None:
+            return self._http("PUT", self.API_INSTANCE_URL + '/' + account_id, None, params)
+        else:
+            return self._http("PUT", self.API_INSTANCE_URL + '/' + account_id + '/op/' + operation_id, None, params)
+
+    def updateInstance(self, instance_id, account_id, operation_id, name, two_factor, lock_on_request):
+        params = {'name': name, 'two_factor': two_factor, 'lock_on_request': lock_on_request}
+
+        if operation_id == None:
+            return self._http("POST", self.API_INSTANCE_URL + "/" + account_id + '/i/' + instance_id, None, params)
+        else:
+            return self._http("POST", self.API_OPERATION_URL + "/" + account_id + '/op/' + operation_id + '/i/' + instance_id, None, params)
+
+    def deleteInstance(self, instance_id, account_id, operation_id=None):
+        if operation_id == None:
+            return self._http("DELETE", self.API_INSTANCE_URL + "/" + account_id + '/i/' + instance_id)
+        else:
+            return self._http("DELETE", self.API_INSTANCE_URL + "/" + account_id + "/op/" + operation_id + "/i/" + instance_id)

--- a/latchauth.py
+++ b/latchauth.py
@@ -39,6 +39,7 @@ class LatchAuth(object):
     API_OPERATION_URL = "/api/" + API_VERSION + "/operation"
     API_SUBSCRIPTION_URL = "/api/" + API_VERSION + "/subscription"
     API_APPLICATION_URL = "/api/" + API_VERSION + "/application"
+    API_INSTANCE_URL = "/api/" + API_VERSION + "/instance"
 
     AUTHORIZATION_HEADER_NAME = "Authorization"
     DATE_HEADER_NAME = "X-11Paths-Date"


### PR DESCRIPTION
He incluido soporte para la nueva funcionalidad de instancias. Se ha usado la misma estructura existente para operaciones, pero con instancias. La unica “limitación” es que no permite añadir multiples instancias a la vez. La razón es por evitar complicar la llamada a createInstance, en la que multiples instancias se podrían pasar como tuples, listas, dict, etc. Están incluidas las mismas funciones que para operaciones: crear, borrar, consultar, modificar y status. Funcionan tanto para instancias de aplicación como de operaciones.